### PR TITLE
Added support for tsx file types.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ In this example, only `component` will be included. `blabla.jsx` does not match 
 - **searchPath**: `String`
   (The path in which to look for components)
 
+- **fileExtension**: `String`
+  (The file extension you are working with. It will change the import style of the components. Written in the form .[fileExtension]. It defaults to '.jsx')
+  (For example: '.tsx'.)
+
 ### createComponentsFile
 
 ```js
@@ -55,7 +59,8 @@ const path = require("path");
 createComponentsFile({
   searchPath: path.join(__dirname, "components"),
   fileName: "app.components.js",
-  outputPath: __dirname
+  outputPath: __dirname,
+  fileExtension: '.tsx'
 });
 ```
 
@@ -94,7 +99,8 @@ const path = require("path");
 createPagesFile({
   fileName: "pages.js",
   searchPath: path.join(__dirname, "pages"),
-  outputPath: __dirname
+  outputPath: __dirname,
+  fileExtension: '.jsx'
 });
 ```
 

--- a/source/create-file.js
+++ b/source/create-file.js
@@ -15,13 +15,12 @@ module.exports = (
     outputPath,
     prettierOptions,
     searchPath,
-    fileExtension
+    fileExtension = ".jsx"
   }
 ) => {
   assert(searchPath, 'Options.searchPath is required.');
   assert(outputPath, 'Options.outputPath is required.');
   assert(fileName, 'Options.fileName is required.');
-  fileExtension = fileExtension ? '.' + fileExtension.trim('.') : '.jsx';
   try {
     const components = klawSync(searchPath, {
       filter: item => path.basename(item.path)[0] !== '.'

--- a/source/create-file.js
+++ b/source/create-file.js
@@ -14,25 +14,30 @@ module.exports = (
     fileName,
     outputPath,
     prettierOptions,
-    searchPath
+    searchPath,
+    fileExtension
   }
 ) => {
   assert(searchPath, 'Options.searchPath is required.');
   assert(outputPath, 'Options.outputPath is required.');
   assert(fileName, 'Options.fileName is required.');
-
+  fileExtension = fileExtension ? '.' + fileExtension.trim('.') : '.jsx';
   try {
     const components = klawSync(searchPath, {
       filter: item => path.basename(item.path)[0] !== '.'
     }).reduce((accumulator, { path: filePath }) => {
-      const metadata = getComponentMetadata(filePath);
+      const metadata = getComponentMetadata(filePath, fileExtension);
 
       return Object.keys(metadata).length > 0
         ? accumulator.concat(metadata)
         : accumulator;
     }, []);
 
-    const fileContent = `${fileHeader}\n\n${stringifier(components, outputPath)}\n`;
+    const fileContent = `${fileHeader}\n\n${stringifier(
+      components,
+      outputPath,
+      fileExtension
+    )}\n`;
 
     writeFile(path.join(outputPath, fileName), fileContent, prettierOptions);
   } catch (error) {

--- a/source/frontmatter.js
+++ b/source/frontmatter.js
@@ -14,12 +14,7 @@ module.exports = function(string, opts) {
 
   if (matches[2] !== undefined) {
     var parse = opts.safeLoad ? yaml.safeLoad : yaml.load;
-
-    try {
-      parsed.data = parse(matches[2]) || {};
-    } catch (err) {
-      throw err;
-    }
+    parsed.data = parse(matches[2]) || {};
   }
 
   if (matches[3] !== undefined) {

--- a/source/get-component-metadata.js
+++ b/source/get-component-metadata.js
@@ -4,10 +4,10 @@ const path = require('path');
 const frontmatter = require('./frontmatter');
 const kebabToPascal = require('@creuna/utils/kebab-to-pascal').default;
 
-function getComponentMetadata(filePath) {
+function getComponentMetadata(filePath, fileExtension) {
   const folderPath = path.dirname(filePath);
   const indexFile = path.join(folderPath, 'index.js');
-  const fileName = path.basename(filePath, '.jsx');
+  const fileName = path.basename(filePath, fileExtension);
   const folderName = path.basename(folderPath);
 
   if (fileName === folderName) {

--- a/source/stringifiers/components-file.js
+++ b/source/stringifiers/components-file.js
@@ -1,9 +1,9 @@
 const importStatement = require('./import-statement');
 
-module.exports = (components = [], outputPath) => {
+module.exports = (components = [], outputPath, fileExtension) => {
   const importStatements = components.reduce(
     (accumulator, { componentName, filePath }) =>
-      accumulator + importStatement(componentName, outputPath, filePath),
+      accumulator + importStatement(componentName, outputPath, filePath, fileExtension),
     ''
   );
 

--- a/source/stringifiers/import-statement.js
+++ b/source/stringifiers/import-statement.js
@@ -3,7 +3,7 @@ const path = require('path');
 module.exports = (name, importerPath, modulePath, fileExtension) => {
   var relativePath = '';
   switch (fileExtension) {
-    case 'tsx':
+    case '.tsx':
       relativePath = path
         .relative(importerPath, modulePath)
         .replace(/\\/g, '/')

--- a/source/stringifiers/import-statement.js
+++ b/source/stringifiers/import-statement.js
@@ -1,7 +1,17 @@
 const path = require('path');
 
-module.exports = (name, importerPath, modulePath) => {
-  const relativePath = path.relative(importerPath, modulePath).replace(/\\/g, '/');
+module.exports = (name, importerPath, modulePath, fileExtension) => {
+  var relativePath = '';
+  switch (fileExtension) {
+    case 'tsx':
+      relativePath = path
+        .relative(importerPath, modulePath)
+        .replace(/\\/g, '/')
+        .replace(/\.[^/.]+$/, '');
+      break;
+    default:
+      relativePath = path.relative(importerPath, modulePath).replace(/\\/g, '/');
+  }
 
   return `import ${name} from './${relativePath}';\n`;
 };

--- a/source/stringifiers/import-statement.js
+++ b/source/stringifiers/import-statement.js
@@ -8,10 +8,10 @@ module.exports = (name, importerPath, modulePath, fileExtension) => {
         .relative(importerPath, modulePath)
         .replace(/\\/g, '/')
         .replace(/\.[^/.]+$/, '');
-      break;
+      return `import {${name}} from './${relativePath}';\n`;
     default:
       relativePath = path.relative(importerPath, modulePath).replace(/\\/g, '/');
+      return `import ${name} from './${relativePath}';\n`;
   }
 
-  return `import ${name} from './${relativePath}';\n`;
 };

--- a/source/stringifiers/pages-file.js
+++ b/source/stringifiers/pages-file.js
@@ -1,9 +1,9 @@
 const importStatement = require('./import-statement');
 
-module.exports = (pages = [], outputPath) => {
+module.exports = (pages = [], outputPath, fileExtension) => {
   const importStatements = pages.reduce(
     (accumulator, { componentName, filePath }) =>
-      accumulator + importStatement(componentName, outputPath, filePath),
+      accumulator + importStatement(componentName, outputPath, filePath, fileExtension),
     ''
   );
 

--- a/source/write-file.js
+++ b/source/write-file.js
@@ -8,7 +8,6 @@ const prettier = require('prettier');
 function writeFile(filePath, fileContent, prettierOptions) {
   const fileName = path.basename(filePath);
   const prettierConfig = Object.assign({ parser: 'babel' }, prettierOptions);
-
   try {
     fs.writeFileSync(filePath, prettier.format(fileContent, prettierConfig));
     console.log(`💾  ${chalk.blueBright(fileName)} saved`);


### PR DESCRIPTION
You can now add fileExtension as an extra parameter to the createComponents, createPages, and createPaths functions. 
It supports any file extension, but some file extensions will require different rules for importing. 
For now it supports the special "tsx" extension module import, where it removes the ".tsx" from the end of the import.
If fileExtension does not get specified, it defaults to ".jsx" file extension and ".jsx" style imports. 